### PR TITLE
Add ergonomic downcast_err API for QueryError

### DIFF
--- a/crates/query-flow/src/error.rs
+++ b/crates/query-flow/src/error.rs
@@ -1,6 +1,8 @@
 //! Error types for query execution.
 
 use std::fmt;
+use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::asset::PendingAsset;
@@ -91,5 +93,152 @@ impl fmt::Display for QueryError {
 impl<T: Into<anyhow::Error>> From<T> for QueryError {
     fn from(err: T) -> Self {
         QueryError::UserError(Arc::new(err.into()))
+    }
+}
+
+impl QueryError {
+    /// Returns a reference to the inner user error if this is a `UserError` variant.
+    pub fn user_error(&self) -> Option<&Arc<anyhow::Error>> {
+        match self {
+            QueryError::UserError(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Attempts to downcast the user error to a specific type.
+    ///
+    /// Returns `Some(&E)` if this is a `UserError` containing an error of type `E`,
+    /// otherwise returns `None`.
+    pub fn downcast_ref<E: std::error::Error + Send + Sync + 'static>(&self) -> Option<&E> {
+        self.user_error().and_then(|e| e.downcast_ref::<E>())
+    }
+
+    /// Returns `true` if this is a `UserError` containing an error of type `E`.
+    pub fn is<E: std::error::Error + Send + Sync + 'static>(&self) -> bool {
+        self.downcast_ref::<E>().is_some()
+    }
+}
+
+/// A typed wrapper around a user error that provides `Deref` access to the inner error type.
+///
+/// This struct holds an `Arc<anyhow::Error>` internally and provides safe access to
+/// the downcasted error reference. The `Arc` ensures the error remains valid for the
+/// lifetime of this wrapper.
+///
+/// # Example
+///
+/// ```ignore
+/// use query_flow::{QueryResultExt, TypedErr};
+///
+/// let result = db.query(MyQuery::new()).downcast_err::<MyError>()?;
+/// match result {
+///     Ok(value) => { /* success */ }
+///     Err(typed_err) => {
+///         // typed_err derefs to &MyError
+///         println!("Error code: {}", typed_err.code);
+///     }
+/// }
+/// ```
+#[derive(Clone)]
+pub struct TypedErr<E> {
+    arc: Arc<anyhow::Error>,
+    _marker: PhantomData<E>,
+}
+
+impl<E: std::error::Error + Send + Sync + 'static> TypedErr<E> {
+    fn new(arc: Arc<anyhow::Error>) -> Option<Self> {
+        // Verify the downcast is valid before constructing
+        if arc.downcast_ref::<E>().is_some() {
+            Some(Self {
+                arc,
+                _marker: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns a reference to the inner error.
+    pub fn get(&self) -> &E {
+        // Safe because we verified the type in `new`
+        self.arc.downcast_ref::<E>().unwrap()
+    }
+}
+
+impl<E: std::error::Error + Send + Sync + 'static> Deref for TypedErr<E> {
+    type Target = E;
+
+    fn deref(&self) -> &E {
+        self.get()
+    }
+}
+
+impl<E: std::error::Error + Send + Sync + 'static> fmt::Debug for TypedErr<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.get(), f)
+    }
+}
+
+impl<E: std::error::Error + Send + Sync + 'static> fmt::Display for TypedErr<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.get(), f)
+    }
+}
+
+/// Extension trait for query results that provides ergonomic error downcasting.
+///
+/// This trait is implemented for `Result<Arc<T>, QueryError>` and allows you to
+/// downcast user errors to a specific type while propagating system errors.
+///
+/// # Example
+///
+/// ```ignore
+/// use query_flow::QueryResultExt;
+///
+/// // Downcast to MyError, propagating system errors and non-matching user errors
+/// let result = db.query(MyQuery::new()).downcast_err::<MyError>()?;
+///
+/// match result {
+///     Ok(value) => println!("Success: {:?}", value),
+///     Err(my_err) => println!("MyError: {}", my_err.code),
+/// }
+/// ```
+pub trait QueryResultExt<T> {
+    /// Attempts to downcast a `UserError` to a specific error type.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Ok(value))` - The query succeeded with `value`
+    /// - `Ok(Err(typed_err))` - The query failed with a `UserError` of type `E`
+    /// - `Err(query_error)` - The query failed with a system error, or a `UserError`
+    ///   that is not of type `E`
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Handle specific error type, propagate others
+    /// let result = db.query(MyQuery::new()).downcast_err::<MyError>()?;
+    /// let value = result.map_err(|e| {
+    ///     eprintln!("MyError occurred: {}", e.message);
+    ///     e
+    /// })?;
+    /// ```
+    fn downcast_err<E: std::error::Error + Send + Sync + 'static>(
+        self,
+    ) -> Result<Result<Arc<T>, TypedErr<E>>, QueryError>;
+}
+
+impl<T> QueryResultExt<T> for Result<Arc<T>, QueryError> {
+    fn downcast_err<E: std::error::Error + Send + Sync + 'static>(
+        self,
+    ) -> Result<Result<Arc<T>, TypedErr<E>>, QueryError> {
+        match self {
+            Ok(value) => Ok(Ok(value)),
+            Err(QueryError::UserError(arc)) => match TypedErr::new(arc.clone()) {
+                Some(typed) => Ok(Err(typed)),
+                None => Err(QueryError::UserError(arc)),
+            },
+            Err(other) => Err(other),
+        }
     }
 }

--- a/crates/query-flow/src/lib.rs
+++ b/crates/query-flow/src/lib.rs
@@ -42,7 +42,7 @@ pub mod tracer;
 
 pub use asset::{AssetKey, AssetLocator, DurabilityLevel, LocateResult, PendingAsset};
 pub use db::Db;
-pub use error::QueryError;
+pub use error::{QueryError, QueryResultExt, TypedErr};
 pub use key::{FullCacheKey, Key};
 pub use loading::AssetLoadingState;
 pub use query::Query;


### PR DESCRIPTION
- Add TypedErr<E> wrapper that holds Arc<anyhow::Error> and provides
  Deref<Target=E> access, solving the temporary drop lifetime issue
- Add QueryResultExt trait with downcast_err<E>() method that returns
  Result<Result<Arc<T>, TypedErr<E>>, QueryError>
- Add helper methods on QueryError: downcast_ref<E>(), is<E>(), user_error()
- Support ? operator for ergonomic error handling:
  let result = db.query(MyQuery).downcast_err::<MyError>()?;