### PR TITLE
Add GC support with external Tracer API

### DIFF
--- a/crates/query-flow/src/lib.rs
+++ b/crates/query-flow/src/lib.rs
@@ -10,6 +10,7 @@
 //! - **Suspense pattern**: Handle async loading with `AssetLoadingState` without coloring functions
 //! - **Type-safe**: Per-query-type caching with compile-time guarantees
 //! - **Early cutoff**: Skip downstream recomputation when values don't change
+//! - **External GC support**: Build custom garbage collection strategies using the Tracer API
 //!
 //! # Example
 //!
@@ -25,6 +26,17 @@
 //! let result = runtime.query(Add::new(1, 2)).unwrap();
 //! assert_eq!(*result, 3);
 //! ```
+//!
+//! # Garbage Collection
+//!
+//! Query-flow provides primitives for implementing custom GC strategies externally:
+//!
+//! - [`Tracer::on_query_key`] - Track query access for LRU/TTL algorithms
+//! - [`QueryRuntime::query_keys`] - Enumerate all cached queries
+//! - [`QueryRuntime::remove`] / [`QueryRuntime::remove_if_unused`] - Remove queries by [`FullCacheKey`]
+//! - [`QueryRuntime::remove_query`] / [`QueryRuntime::remove_query_if_unused`] - Remove queries by typed key
+//!
+//! See the [`tracer`] module and GC methods on [`QueryRuntime`] for details.
 
 // Allow the macro to reference query_flow types when used inside this crate
 extern crate self as query_flow;


### PR DESCRIPTION
- Add Tracer::on_query_key() hook for tracking query access (for LRU/TTL)
- Add QueryRuntime::query_keys() to enumerate all cached query keys
- Add QueryRuntime::remove_query_if_unused<Q>() for typed conditional removal
- Add QueryRuntime::remove() for type-erased FullCacheKey removal
- Add QueryRuntime::remove_if_unused() for safe GC (respects dependents)
- Add comprehensive tests for GC APIs
- Update lib.rs documentation with GC feature description

This enables users to implement custom GC strategies (LRU, TTL, manual roots)
externally without any overhead when GC is not used. The API is algorithm-agnostic
and whale internals remain hidden.