### PR TITLE
Remove MissingDependency error variant, use UserError instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,6 @@ Queries return `Result<Arc<Output>, QueryError>`. The error variants are:
 - `Suspend` - An asset is not yet available. See [Suspense Pattern](#suspense-pattern).
 - `Cycle` - A dependency cycle was detected in the query graph.
 - `Cancelled` - Query explicitly returned cancellation (not cached, unlike `UserError`).
-- `MissingDependency` - An asset locator indicated the asset is not found or not allowed.
 - `DependenciesRemoved` - Dependencies were removed by another thread during execution.
 - `InconsistentAssetResolution` - An asset was resolved during query execution, possibly causing inconsistent state.
 

--- a/crates/query-flow-inspector/src/events.rs
+++ b/crates/query-flow-inspector/src/events.rs
@@ -222,12 +222,6 @@ pub enum FlowEvent {
     // === Error Events ===
     /// Dependency cycle was detected.
     CycleDetected { path: Vec<QueryKey> },
-
-    /// Missing dependency error occurred.
-    MissingDependency {
-        query: QueryKey,
-        dependency_description: String,
-    },
 }
 
 /// A complete trace of events for a query execution tree.
@@ -279,10 +273,6 @@ pub enum EventKind {
     },
     CycleDetected {
         path: Vec<QueryKey>,
-    },
-    MissingDependency {
-        query: QueryKey,
-        dependency_description: String,
     },
 }
 
@@ -336,13 +326,6 @@ impl From<&FlowEvent> for EventKind {
                 reason: reason.clone(),
             },
             FlowEvent::CycleDetected { path } => EventKind::CycleDetected { path: path.clone() },
-            FlowEvent::MissingDependency {
-                query,
-                dependency_description,
-            } => EventKind::MissingDependency {
-                query: query.clone(),
-                dependency_description: dependency_description.clone(),
-            },
         }
     }
 }
@@ -408,8 +391,7 @@ fn matches_query(event: &FlowEvent, query: &QueryKey) -> bool {
         | FlowEvent::CacheCheck { query: q, .. }
         | FlowEvent::QueryEnd { query: q, .. }
         | FlowEvent::EarlyCutoffCheck { query: q, .. }
-        | FlowEvent::QueryInvalidated { query: q, .. }
-        | FlowEvent::MissingDependency { query: q, .. } => q == query,
+        | FlowEvent::QueryInvalidated { query: q, .. } => q == query,
         FlowEvent::DependencyRegistered {
             parent, dependency, ..
         } => parent == query || dependency == query,

--- a/crates/query-flow-inspector/src/lib.rs
+++ b/crates/query-flow-inspector/src/lib.rs
@@ -40,7 +40,7 @@
 //! - **Dependency Tracking**: `DependencyRegistered`, `AssetDependencyRegistered`
 //! - **Early Cutoff**: `EarlyCutoffCheck`
 //! - **Asset Events**: `AssetRequested`, `AssetResolved`, `AssetInvalidated`
-//! - **Error Events**: `CycleDetected`, `MissingDependency`
+//! - **Error Events**: `CycleDetected`
 //!
 //! See [`FlowEvent`] for the complete list.
 //!

--- a/crates/query-flow-inspector/src/tracer_impl.rs
+++ b/crates/query-flow-inspector/src/tracer_impl.rs
@@ -174,14 +174,6 @@ impl Tracer for EventSinkTracer {
             path: path.into_iter().map(|k| k.into()).collect(),
         });
     }
-
-    #[inline]
-    fn on_missing_dependency(&self, query: TracerQueryKey, dependency_description: String) {
-        self.sink.emit(FlowEvent::MissingDependency {
-            query: query.into(),
-            dependency_description,
-        });
-    }
 }
 
 #[cfg(test)]

--- a/crates/query-flow/src/asset.rs
+++ b/crates/query-flow/src/asset.rs
@@ -120,9 +120,7 @@ pub enum LocateResult<A> {
 ///         // Access config to check if path is allowed
 ///         let config = db.query(GetConfig)?.clone();
 ///         if !config.allowed_paths.contains(&key.0) {
-///             return Err(QueryError::MissingDependency {
-///                 description: format!("Path not allowed: {:?}", key.0),
-///             });
+///             return Err(anyhow::anyhow!("Path not allowed: {:?}", key.0).into());
 ///         }
 ///
 ///         // Return pending for async loading

--- a/crates/query-flow/src/error.rs
+++ b/crates/query-flow/src/error.rs
@@ -39,12 +39,6 @@ pub enum QueryError {
     /// Query execution was cancelled.
     Cancelled,
 
-    /// A required dependency is missing.
-    MissingDependency {
-        /// Description of the missing dependency.
-        description: String,
-    },
-
     /// Dependencies were removed during query execution.
     ///
     /// This can happen if another thread removes queries or assets
@@ -83,9 +77,6 @@ impl fmt::Display for QueryError {
                 write!(f, "dependency cycle detected: {}", path.join(" -> "))
             }
             QueryError::Cancelled => write!(f, "query cancelled"),
-            QueryError::MissingDependency { description } => {
-                write!(f, "missing dependency: {}", description)
-            }
             QueryError::DependenciesRemoved { missing_keys } => {
                 write!(
                     f,

--- a/crates/query-flow/src/tracer.rs
+++ b/crates/query-flow/src/tracer.rs
@@ -196,10 +196,6 @@ pub trait Tracer: Send + Sync + 'static {
     #[inline]
     fn on_cycle_detected(&self, _path: Vec<TracerQueryKey>) {}
 
-    /// Called when a missing dependency error occurs.
-    #[inline]
-    fn on_missing_dependency(&self, _query: TracerQueryKey, _dependency_description: String) {}
-
     /// Called when a query is accessed, providing the [`FullCacheKey`] for GC tracking.
     ///
     /// This is called at the start of each query execution, before `on_query_start`.


### PR DESCRIPTION
MissingDependency was a user-caused error state that was being
treated specially by the library. Since it represents domain-level
errors (asset not found, path not allowed, etc.), it should be
handled as UserError which provides:

- Consistent caching behavior via error_comparator
- Simpler API surface
- Library doesn't special-case domain concepts

Changes:
- Remove QueryError::MissingDependency variant
- Convert type mismatch errors to UserError in runtime
- Remove Tracer::on_missing_dependency (was never called)
- Remove FlowEvent::MissingDependency from inspector
- Update tests to use UserError pattern matching
- Update documentation